### PR TITLE
Add GLIS test runner for MPI testing.

### DIFF
--- a/reports/src/boost_wide_report.py
+++ b/reports/src/boost_wide_report.py
@@ -60,6 +60,7 @@ default_filter_runners = {
         '.*jc-bell',
         'CrystaX.*',
         'marshall-.*',
+        'GLIS.*',
         ]
     }
 


### PR DESCRIPTION
I am mostly interested in Boost.MPI for which we do not have a lot of testing done.

Boost.MPI depends on the underlying MPI implementation so I might have a
few different flavors. In the past it's been not so uncommon to have bugs that showed up with one implementation and not another. 
Boost.MPI depends a lot on Boost.serialization, so it is important to be able to check that the changes in serialization do not break Boost.MPI.
Boost.graph_parallel depends on Boost.MPI.  
