### PR TITLE
Do not require C++11

### DIFF
--- a/common/src/process_jam_log.cpp
+++ b/common/src/process_jam_log.cpp
@@ -672,7 +672,7 @@ int process_jam_log( const std::vector<std::string> & args )
         std::cout << "Abort: option --input-file requires a filename argument\n";
         std::exit(1);
       }
-      input = new std::ifstream( *args_i );
+      input = new std::ifstream( args_i->c_str() );
     }
     else if ( (*args_i)[1] == '-' )
     {

--- a/library_status/src/library_status.cpp
+++ b/library_status/src/library_status.cpp
@@ -36,6 +36,7 @@ namespace xml = boost::tiny_xml;
 #include <boost/iterator/transform_iterator.hpp>
 
 #include <cstdlib>  // for abort, exit, system
+#include <cstddef>  // for nullptr
 #include <string>
 #include <vector>
 #include <set>
@@ -1000,7 +1001,7 @@ int cpp_main( int argc, char * argv[] ) // note name!
                     break;
                 }
             }
-            log_name = std::tmpnam(nullptr);
+            log_name = std::tmpnam(0);
             log_name += "-library_status.log";
             process_jam_log_args.push_back("--input-file");
             process_jam_log_args.push_back(log_name);


### PR DESCRIPTION
C++11 is used in two places where it can be easilly avoided (one
nullptr used in a clib function call and one std::string ctor for
stream). It does not match the default setting of some  widly used
compiler (Intel's icpc for one).
One alternative would be to have b2 sorting out the right option.
