### PR TITLE
Install executable in bin dir.

### DIFF
--- a/testing/build/Jamfile.jam
+++ b/testing/build/Jamfile.jam
@@ -11,7 +11,7 @@ exe process_jam_log
     ;
 explicit process_jam_log ;
 
-alias install : exec ;
+alias install : exec scripts ;
 install exec
     :
     process_jam_log/<variant>release
@@ -20,3 +20,13 @@ install exec
     <location>$(INSTALL_PREFIX_EXEC)
     ;
 explicit install exec ;
+
+install scripts
+    :
+    ../src/regression.py
+    ../src/collect_and_upload_logs.py
+    ../src/process_jam_log.py
+    :
+    <location>$(INSTALL_PREFIX_EXEC)
+    ;
+explicit install scripts ;


### PR DESCRIPTION
There is no reason to install executables in different location
based on the language they'rewritten.
So python scripts (which are executables) should be available in the exec_prefix
directory (typically stage/bin).

One side effect is that when in regression.py, we know were
to find, says process_bjam_log whithout having to assume anything else than the fact that executables are n the same dir.
