### PR TITLE
Display failure type in the cell of summary page table.

### DIFF
--- a/reports/src/add_expected_results.cpp
+++ b/reports/src/add_expected_results.cpp
@@ -195,6 +195,20 @@ void process_test_log(test_structure_t::test_log_t& test_log,
     test_log.status = status;
     test_log.is_new = is_new;
     test_log.category = category;
+
+    {
+        test_log.fail_info = test_structure_t::fail_none;
+
+        typedef boost::unordered_map<std::string, test_structure_t::target_t>::const_iterator iterator;
+        iterator it, end = test_log.targets.end();
+        if ( ( it = test_log.targets.find("compile") ) != end && !it->second.result ) {
+            test_log.fail_info = test_structure_t::fail_comp;
+        } else if ( ( it = test_log.targets.find("link") ) != end && !it->second.result ) {
+            test_log.fail_info = test_structure_t::fail_link;
+        } else if ( ( it = test_log.targets.find("run") ) != end && !it->second.result ) {
+            test_log.fail_info = test_structure_t::fail_run;
+        }
+    }
 }
 
 // requires: source is a Git branch name

--- a/reports/src/result_page.cpp
+++ b/reports/src/result_page.cpp
@@ -78,6 +78,18 @@ void insert_cell_link(html_writer& document, const std::string& result, const st
     }
 }
      
+std::string failure_link_name(test_structure_t::test_log_t const& log)
+{
+    if ( log.fail_info == test_structure_t::fail_comp )
+        return "comp";
+    else if ( log.fail_info == test_structure_t::fail_link )
+        return "link";
+    else if ( log.fail_info == test_structure_t::fail_run )
+        return "run";
+    else
+        return "fail";
+}
+
 // requires:
 void insert_cell_developer(html_writer& document,
                            const failures_markup_t& explicit_markup,
@@ -110,7 +122,7 @@ void insert_cell_developer(html_writer& document,
         }
         BOOST_FOREACH(test_log_group_t::value_type log, test_logs) {
             if(!log->result && !log->status) {
-                insert_cell_link(document, "fail", cell_link);
+                insert_cell_link(document, failure_link_name(*log), cell_link);
                 goto done;
             }
         }

--- a/reports/src/xml.hpp
+++ b/reports/src/xml.hpp
@@ -58,6 +58,9 @@ struct expected_results_t {
 void load_expected_results(node_ptr root, expected_results_t& expected_results);
 
 struct test_structure_t {
+    enum fail_info_t {
+        fail_none, fail_comp, fail_link, fail_run
+    };
     struct target_t {
         std::string type;
         std::string timestamp;
@@ -75,6 +78,7 @@ struct test_structure_t {
         std::string target_directory;
         bool result;
         bool expected_result;
+        fail_info_t fail_info;
         std::string expected_reason;
         bool status;
         bool is_new;


### PR DESCRIPTION
For new failures instead of "fail" display "comp", "link" or "run".

Currently only the failure cell name is changed but at the end I'd like to achieve the effect similar to this:
https://github.com/awulkiew/summary-enhancer
where different colors are used for various failure types and failures "File too big", "Time limit expected" or "Internal compiler error" are marked in a special way as well.

In case if this upgrade was desireable (I think such summary page is a lot more convenient to read) should I:
- create additional CSS classes for various failure types and replace currently used one `library-fail-unexpected-new`, e.g. `library-fail-unexpected-new-comp`, `library-fail-unexpected-new-link`, etc.
- add classes for failure type defining colors and then use 2 classes per cell, the old one plus the new failure type class, e.g. `class="library-fail-unexpected-new,library-fail-type-comp"`,
- add inline HTML style attribute setting the color in place and leaving the class untouched?
