### PR TITLE
Fix the ToC (quick and dirty).

### DIFF
--- a/reports/src/boost_report.cpp
+++ b/reports/src/boost_report.cpp
@@ -111,10 +111,13 @@ int main(int argc, char* argv[]) {
         modes.push_back("developer");
         modes.push_back("user");
 
+        // NOTE: The ToC is generated in result_page(). In the currently used setup
+        // only the non-release result_page is generated. To be consistent with it,
+        // the non-release issues page is generated.
         if (reports.count("i") != 0) {
             std::cout << "Generating issues page" << std::endl;
             issues_list("developer", structure, markup,
-                        true, tag, now, warnings, "");
+                        false, tag, now, warnings, "");
         }
 
         BOOST_FOREACH(const std::string& mode, modes) {

--- a/reports/src/result_page.cpp
+++ b/reports/src/result_page.cpp
@@ -370,11 +370,11 @@ void boost::regression::result_page(const test_structure_t& tests,
                    "    </div>\n";
         }
 
-        toc << "    <div class=\"toc-header-entry\">\n";
+        /*toc << "    <div class=\"toc-header-entry\">\n";
 
         insert_view_link(toc, "index", "toc-entry", release);
 
-        toc << "    </div>\n";
+        toc << "    </div>\n";*/
 
         toc << "    <hr/>\n";
 


### PR DESCRIPTION
Generate non-release Unresolved Issues page.
Remove Relese View link from ToC.
