### PR TITLE
Generate the report containing the warnings.

### DIFF
--- a/reports/src/add_expected_results.cpp
+++ b/reports/src/add_expected_results.cpp
@@ -215,6 +215,7 @@ void process_test_log(test_structure_t::test_log_t& test_log,
     test_log.is_new = is_new;
     test_log.category = category;
     test_log.fail_info = test_structure_t::fail_none;
+    test_log.pass_warning = false;
 
     // if it is an unexpected failure, either regression or new
     if (!actual_result && expected_result) {
@@ -241,6 +242,16 @@ void process_test_log(test_structure_t::test_log_t& test_log,
             test_log.fail_info = test_structure_t::fail_link;
         } else if ( ( it = test_log.targets.find("run") ) != end && !it->second.result ) {
             test_log.fail_info = test_structure_t::fail_run;
+        }
+    } else if (actual_result) {
+        typedef boost::unordered_map<std::string, test_structure_t::target_t>::const_iterator iterator;
+        iterator it, end = test_log.targets.end();
+        if ( ( it = test_log.targets.find("compile") ) != end ) {
+            BOOST_ASSERT(it->second.contents);
+            boost::string_ref val(it->second.contents->value(), it->second.contents->value_size());
+            if ( find_regex(val, "warning") ) {
+                test_log.pass_warning = true;
+            }
         }
     }
 }

--- a/reports/src/common.cpp
+++ b/reports/src/common.cpp
@@ -287,6 +287,17 @@ std::string boost::regression::log_file_path(
     }
 }
 
+std::string boost::regression::warnings_file_path(
+    const std::string& runner,
+    const std::string& toolset,
+    const std::string& library,
+    const std::string& test_name,
+    const std::string& release_postfix)
+{
+    return output_file_path(runner + "-" + library + "-" + toolset + "-warnings" + release_postfix)
+            + (test_name.empty() ? std::string("") : std::string("#") + test_name);
+}
+
 bool boost::regression::show_library(const failures_markup_t& explicit_markup, const std::string& library, bool release) {
     return !release || !is_library_beta(explicit_markup, library);
 }

--- a/reports/src/common.hpp
+++ b/reports/src/common.hpp
@@ -48,6 +48,13 @@ std::string log_file_path(
     const std::string& runner,
     const std::string& release_postfix = "");
 
+std::string warnings_file_path(
+    const std::string& runner,
+    const std::string& toolset,
+    const std::string& library,
+    const std::string& test_name = "",
+    const std::string& release_postfix = "");
+
 bool show_library(const failures_markup_t& explicit_markup, const std::string& library, bool release);
 bool show_output(const failures_markup_t& markup, const test_structure_t::test_log_t& test_log);
 bool show_toolset(const failures_markup_t& explicit_markup, const std::string& toolset, bool release);

--- a/reports/src/result_page.cpp
+++ b/reports/src/result_page.cpp
@@ -114,6 +114,19 @@ void insert_cell_developer(html_writer& document,
                 goto done;
             }
         }
+
+        bool is_pass_warning_found = false;
+        BOOST_FOREACH(test_log_group_t::value_type log, test_logs) {
+            if ( log->pass_warning ){
+                is_pass_warning_found = true;
+                break;
+            }
+        }
+        if ( is_pass_warning_found ) {
+            // anchor doesn't work for iframes
+            cell_link = warnings_file_path(runner, toolset, library, ""/*test_logs.front()->test_name*/, release_postfix(release));
+        }
+
         insert_cell_link(document, "pass", cell_link);
     }
 done:

--- a/reports/src/xml.cpp
+++ b/reports/src/xml.cpp
@@ -291,6 +291,12 @@ std::string escape_characters(const char* input, std::size_t size) {
 }
 }
 
+void boost::regression::write_characters(html_writer& document, const std::string& s)
+{
+    if(!s.empty())
+        ::write_characters(document, s.c_str(), s.size());
+}
+
 std::string boost::regression::escape_xml(const std::string& s) {
     return escape_characters(s.data(), s.size());
 }

--- a/reports/src/xml.hpp
+++ b/reports/src/xml.hpp
@@ -12,12 +12,12 @@
 #include <string>
 #include <vector>
 #include <iosfwd>
+#include <boost/date_time/posix_time/ptime.hpp>
+#include <boost/property_tree/detail/rapidxml.hpp>
+#include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/unordered_set.hpp>
-#include <boost/property_tree/detail/rapidxml.hpp>
-#include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/variant.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include "html_writer.hpp"
 
@@ -80,6 +80,7 @@ struct test_structure_t {
         bool result;
         bool expected_result;
         fail_info_t fail_info;
+        bool pass_warning;
         std::string expected_reason;
         bool status;
         bool is_new;
@@ -126,6 +127,8 @@ bool check_attr(node_ptr element, const std::string& element1, const std::string
 node_ptr lookup_element(node_ptr element, const std::string& name);
 int count_element(node_ptr element, const std::string& name);
 std::string value_of(node_ptr element);
+
+void write_characters(html_writer& document, const std::string& s);
 
 std::string escape_xml(const std::string& s);
 void write_to_stream(html_writer& os, node_ptr node, bool trim=false);


### PR DESCRIPTION
Currently the compiler output can be seen only in the case of a failure. This PR makes it possible to see compiler warnings reported for a library for passing tests.

To prevent the files bloat and save the disk space all of the warnings for a whole library and runner/toolset are gathered together in one file. Furthermore only the lines of a compiler output containing the warnings are extracted and displayed. To decrease the file size even more each warning is displayed only once for the whole library.

The warnings page is displayed after clicking on the "pass" link on the library results page. If there is no warnings the link is not active. For instance the fragment of warnings page for Algorithm and GCC6.0 looks like this:
#### Warnings: trippels-powerpc64le-gcc-6.0-c++14 - algorithm / gcc-6.0.0
##### Rev 3bec1cc18e5fdf87b8f067c26fadfaa5659c9004 / Sat, 30 May 2015 08:01:35 +0000

---
##### all_of_test

```
../boost/smart_ptr/detail/shared_count.hpp:396:33: warning: ???template<class> class std::auto_ptr??? is deprecated [-Wdeprecated-declarations]
../boost/smart_ptr/shared_ptr.hpp:249:65: warning: ???template<class> class std::auto_ptr??? is deprecated [-Wdeprecated-declarations]
../boost/smart_ptr/shared_ptr.hpp:448:31: warning: ???template<class> class std::auto_ptr??? is deprecated [-Wdeprecated-declarations]
../boost/smart_ptr/shared_ptr.hpp:461:22: warning: ???template<class> class std::auto_ptr??? is deprecated [-Wdeprecated-declarations]
../boost/smart_ptr/shared_ptr.hpp:538:34: warning: ???template<class> class std::auto_ptr??? is deprecated [-Wdeprecated-declarations]
../boost/smart_ptr/shared_ptr.hpp:547:34: warning: ???template<class> class std::auto_ptr??? is deprecated [-Wdeprecated-declarations]
../boost/smart_ptr/shared_ptr.hpp:549:38: warning: ???template<class> class std::auto_ptr??? is deprecated [-Wdeprecated-declarations]
../boost/smart_ptr/scoped_ptr.hpp:68:31: warning: ???template<class> class std::auto_ptr??? is deprecated [-Wdeprecated-declarations]
../boost/get_pointer.hpp:27:40: warning: ???template<class> class std::auto_ptr??? is deprecated [-Wdeprecated-declarations]
```
##### any_of_test

```
(9 warnings already reported)
```
##### clamp_test

```
../libs/algorithm/test/clamp_test.cpp:92:70: warning: overflow in implicit constant conversion [-Woverflow]
(10 warnings already reported)
```

...
