### PR TITLE
Improve the warnings output in report.

### DIFF
--- a/reports/src/boost_report.cpp
+++ b/reports/src/boost_report.cpp
@@ -97,6 +97,9 @@ int main(int argc, char* argv[]) {
                     add_expected_results(*test_run, markup, expected, tag);
                     std::cout << "Generating links pages" << std::endl;
                     // must be run before test_results is discarded
+                    // NOTE: it generates the test results for all of the combinations
+                    // of release/not-release and developer/user
+                    // TODO: one could generate only the links that are really needed
                     if(reports.count("l"))
                         links_page(markup, *test_run);
                 } catch(std::ios_base::failure& e) {

--- a/reports/src/common.cpp
+++ b/reports/src/common.cpp
@@ -232,6 +232,8 @@ std::string boost::regression::escape_uri(const std::string& path) {
             // We're intentionally allowing '/' to go through.
             // to escape it as well, use escape_literal_uri
             ch == '/' ||
+            // The same for '#' (anchor)
+            ch == '#' ||
             // FIXME: reserved characters
             ch == '+')
             result += ch;

--- a/reports/src/links_page.cpp
+++ b/reports/src/links_page.cpp
@@ -69,15 +69,28 @@ void links_page(const failures_markup_t& explicit_markup,
     if(test_logs.size() > 1) {
         // utils::log("  Processing variants");
 
-        std::string variants_file_path = output_file_path(runner_id + "-" + library_name + "-" + toolset_name + "-" + test_name + "-variants");
-
-        write_variants_file(explicit_markup, variants_file_path, test_logs, runner_id, revision, timestamp);
-
-        BOOST_FOREACH(const std::string& release_postfix, postfixes) {
-            BOOST_FOREACH(const std::string& directory, dirs) {
-                std::string variants__file_path = directory + "/" + (encode_path(runner_id + "-" + library_name + "-" + toolset_name + "-" + test_name + "-variants_" + release_postfix) + ".html");
-                write_variants_reference_file(variants__file_path, "../" + variants_file_path, release_postfix, test_logs, runner_id);
+        // check if there are some failures or warnings
+        bool should_generate_variants = false;
+        BOOST_FOREACH(test_structure_t::test_log_t const& log, test_logs) {
+            if ( !log.result || !log.status || log.pass_warning ) {
+                should_generate_variants = true;
             }
+        }
+
+        // generate variants page only if there are some failures or warnings
+        if ( should_generate_variants ) {
+
+            std::string variants_file_path = output_file_path(runner_id + "-" + library_name + "-" + toolset_name + "-" + test_name + "-variants");
+
+            write_variants_file(explicit_markup, variants_file_path, test_logs, runner_id, revision, timestamp);
+
+            BOOST_FOREACH(const std::string& release_postfix, postfixes) {
+                BOOST_FOREACH(const std::string& directory, dirs) {
+                    std::string variants__file_path = directory + "/" + (encode_path(runner_id + "-" + library_name + "-" + toolset_name + "-" + test_name + "-variants_" + release_postfix) + ".html");
+                    write_variants_reference_file(variants__file_path, "../" + variants_file_path, release_postfix, test_logs, runner_id);
+                }
+            }
+
         }
     }
 

--- a/reports/src/result_page.cpp
+++ b/reports/src/result_page.cpp
@@ -66,10 +66,10 @@ typedef std::map<test_case_id_t, test_logs_by_run_t> test_logs_t;
 
 // requires: result contains no HTML special characters
 // requires: log_link must not contain a '/' derived from the input (This won't actually break anything, though)
-void insert_cell_link(html_writer& document, const std::string& result, const std::string& log_link) {
+void insert_cell_link(html_writer& document, const std::string& result, const std::string& log_link, const std::string& target = "_top") {
     if(log_link != "") {
         document << "&#160;&#160;"
-                    "<a href=\"" << escape_uri(log_link) << "\" class=\"log-link\" target=\"_top\">"
+                    "<a " << "href=\"" << escape_uri(log_link) << "\" class=\"log-link\" target=\"" << target << "\">"
                  << result <<
                     "</a>"
                     "&#160;&#160;";
@@ -130,16 +130,17 @@ void insert_cell_developer(html_writer& document,
             }
         }
 
+        std::string target = "_top";
         // if there are warnings generate the warnings link
         if ( is_pass_warning_found ) {
-            // anchor doesn't work for iframes
-            cell_link = warnings_file_path(runner, toolset, library, ""/*test_logs.front()->test_name*/, release_postfix(release));
+            cell_link = std::string("../")+warnings_file_path(runner, toolset, library, test_logs.front()->test_name, release_postfix(release));
+            target = "docframe";
         // if there are no failures do not generate the link
         } else if ( !is_not_pass ) {
             cell_link = "";
         }
 
-        insert_cell_link(document, "pass", cell_link);
+        insert_cell_link(document, "pass", cell_link, target);
     }
 done:
     document << "</td>\n";


### PR DESCRIPTION
- don't generate the variants output pages if all of the underlying tests pass
- modify links to lead into the specific test on a warnings page
- show all warnings on a warning page for a library/toolset
