### PR TITLE
Fix invalid usage of a element.

### DIFF
--- a/reports/src/issues_page.cpp
+++ b/reports/src/issues_page.cpp
@@ -159,9 +159,9 @@ void write_issues_list(const std::string& path,
         std::size_t failures = count_failures(library.second);
 
         document << "      <h2>\n";
-        document << "        <a name=\"" << escape_uri(library.first) << "\"/>\n";
         document << "        <a class=\"hover-link\" href=\"" << escape_uri(library_page)
-                 << release_postfix << ".html\" target=\"_top\">\n";
+                 << release_postfix << ".html\" target=\"_top\" name=\""
+                 << escape_uri(library.first) << "\">\n";
         document << "        " << escape_xml(library.first) << " (" << failures
                  << " failure" << (failures == 1? "":"s") << ")\n";
         document << "        </a>\n";


### PR DESCRIPTION
The end tag of A elem. cannot be omitted.
