### PR TITLE
Add intel-.* to master summary reports.

### DIFF
--- a/reports/src/boost_wide_report.py
+++ b/reports/src/boost_wide_report.py
@@ -64,6 +64,7 @@ default_filter_runners = {
         'jessicah-haiku.*',
         'oracle-.*',
         'igaztanaga.*',
+        'intel-.*',
         ]
     }
 


### PR DESCRIPTION
I'm submitting boost master testing with the Intel 16.0 Linux compiler, uploaded to the file intel-linux-master.zip
Would like the results displayed at the boost url.
I plan to add Windows testing also, so I'm using file globbing. 
Currently for Linux develop testing I'm using the filename mibintc\* but I plan to change that.
Look OK?
Thanks and regards, Melanie
