### PR TITLE
[report] Handle more compiler errors.

### DIFF
--- a/reports/src/add_expected_results.cpp
+++ b/reports/src/add_expected_results.cpp
@@ -229,7 +229,7 @@ void process_test_log(test_structure_t::test_log_t& test_log,
             
             BOOST_ASSERT(it->second.contents);
             boost::string_ref val(it->second.contents->value(), it->second.contents->value_size());
-            if ( find_regex(val, "([Ii]nternal error)|([Ii]nternal compiler error)|([Ss]egmentation fault)|(unable to execute command: Aborted)") ) {
+            if ( find_regex(val, "([Ii]nternal error)|((?i)Internal compiler error(?-i))|([Ss]egmentation fault)|(unable to execute command: Aborted)") ) {
                 test_log.fail_info = test_structure_t::fail_cerr;
             } else if ( find_regex(val, "second time limit exceeded") ) {
                 test_log.fail_info = test_structure_t::fail_time;

--- a/reports/src/add_expected_results.cpp
+++ b/reports/src/add_expected_results.cpp
@@ -233,7 +233,7 @@ void process_test_log(test_structure_t::test_log_t& test_log,
                 test_log.fail_info = test_structure_t::fail_cerr;
             } else if ( find_regex(val, "second time limit exceeded") ) {
                 test_log.fail_info = test_structure_t::fail_time;
-            } else if ( find_regex(val, "(File too big)|(/bigobj)") ) {
+            } else if ( find_regex(val, "File too big") ) {
                 test_log.fail_info = test_structure_t::fail_file;
             } else if ( find_regex(val, "virtual memory exhausted") ) {
                 test_log.fail_info = test_structure_t::fail_other;

--- a/reports/src/add_expected_results.cpp
+++ b/reports/src/add_expected_results.cpp
@@ -229,7 +229,7 @@ void process_test_log(test_structure_t::test_log_t& test_log,
             
             BOOST_ASSERT(it->second.contents);
             boost::string_ref val(it->second.contents->value(), it->second.contents->value_size());
-            if ( find_regex(val, "([Ii]nternal error)|((?i)Internal compiler error(?-i))|([Ss]egmentation fault)|(unable to execute command: Aborted)") ) {
+            if ( find_regex(val, "([Ii]nternal error)|((?i)Internal compiler error(?-i))|([Ss]egmentation fault)|(unable to execute command: Abort)") ) {
                 test_log.fail_info = test_structure_t::fail_cerr;
             } else if ( find_regex(val, "second time limit exceeded") ) {
                 test_log.fail_info = test_structure_t::fail_time;


### PR DESCRIPTION
This PR improves/fixes error kind matching on the regression matrix. With this change msvc7 and clang/darwin internal compiler errors are correctly reported and msvc /bigobj false positives are avoided.