### PR TITLE
Simultaneous support for Python 2 and Python 3

### DIFF
--- a/testing/src/build_log.py
+++ b/testing/src/build_log.py
@@ -389,22 +389,22 @@ class BuildConsoleSummaryReport(object):
                 self.fail_print("  {0}/{1}",test['library'],test['test-name'])
     
     def p_print(self, format, *args, **kargs):
-        print format.format(*args,**kargs)
+        print(format.format(*args,**kargs))
     
     def info_print(self, format, *args, **kargs):
-        print self.INFO+format.format(*args,**kargs)+self.ENDC
+        print(self.INFO+format.format(*args,**kargs)+self.ENDC)
     
     def header_print(self, format, *args, **kargs):
-        print self.HEADER+format.format(*args,**kargs)+self.ENDC
+        print(self.HEADER+format.format(*args,**kargs)+self.ENDC)
     
     def ok_print(self, format, *args, **kargs):
-        print self.OK+format.format(*args,**kargs)+self.ENDC
+        print(self.OK+format.format(*args,**kargs)+self.ENDC)
     
     def warn_print(self, format, *args, **kargs):
-        print self.WARNING+format.format(*args,**kargs)+self.ENDC
+        print(self.WARNING+format.format(*args,**kargs)+self.ENDC)
     
     def fail_print(self, format, *args, **kargs):
-        print self.FAIL+format.format(*args,**kargs)+self.ENDC
+        print(self.FAIL+format.format(*args,**kargs)+self.ENDC)
 
 class Main(object):
     

--- a/testing/src/collect_and_upload_logs.py
+++ b/testing/src/collect_and_upload_logs.py
@@ -328,7 +328,7 @@ def compress_file( file_path, archive_path ):
         z.write( file_path, os.path.basename( file_path ) )
         z.close()
         utils.log( 'Done writing "%s".'% archive_path )
-    except Exception, msg:
+    except Exception as msg:
         utils.log( 'Warning: Compressing falied (%s)' % msg )
         utils.log( '         Trying to compress using a platform-specific tool...' )
         try: import zip_cmd

--- a/testing/src/collect_and_upload_logs.py
+++ b/testing/src/collect_and_upload_logs.py
@@ -120,7 +120,8 @@ def collect_test_logs( input_dirs, test_results_writer ):
     utils.log( 'Collecting test logs ...' )
     for input_dir in input_dirs:
         utils.log( 'Walking directory "%s" ...' % input_dir )
-        os.path.walk( input_dir, process_test_log_files, test_results_writer )
+        for name, dirs, files in os.walk( input_dir ):
+            process_test_log_files(test_results_writer, name, files)
 
 dart_status_from_result = {
     'succeed': 'passed',
@@ -237,7 +238,8 @@ def publish_test_logs(
 
     for input_dir in input_dirs:
         utils.log( 'Walking directory "%s" ...' % input_dir )
-        os.path.walk( input_dir, _publish_test_log_files_, None )
+        for name, dirs, files in os.path.walk( input_dir ):
+            _publish_test_log_files_( None, name, files)
     if dart_server:
         try:
             rpc_transport = None

--- a/testing/src/collect_and_upload_logs.py
+++ b/testing/src/collect_and_upload_logs.py
@@ -17,13 +17,19 @@ try:
     import xmlrpc.client as xmlrpclib
 except ImportError:
     import xmlrpclib
-import httplib
+try:
+    import http.client as httplib
+except ImportError:
+    import httplib
 
 import os.path
 import string
 import sys
 import re
-import urlparse
+try:
+    import urllib.parse as urlparse
+except ImportError:
+    import urlparse
 import getopt
 import inspect
 
@@ -142,7 +148,7 @@ class xmlrpcProxyTransport(xmlrpclib.Transport):
         self.proxy = proxy
     def make_connection(self, host):
         self.realhost = host
-        return httplib.HTTP(self.proxy)
+        return httplib.HTTPConnection(self.proxy)
     def send_request(self, connection, handler, request_body):
         connection.putrequest('POST','http://%s%s' % (self.realhost,handler))
     def send_host(self, connection, host):

--- a/testing/src/collect_and_upload_logs.py
+++ b/testing/src/collect_and_upload_logs.py
@@ -13,7 +13,10 @@ import ftplib
 import time
 import stat
 import xml.dom.minidom
-import xmlrpclib
+try:
+    import xmlrpc.client as xmlrpclib
+except ImportError:
+    import xmlrpclib
 import httplib
 
 import os.path

--- a/testing/src/collect_and_upload_logs.py
+++ b/testing/src/collect_and_upload_logs.py
@@ -3,8 +3,8 @@
 # Copyright (c) MetaCommunications, Inc. 2003-2007
 # Copyright Rene Rivera 2015
 #
-# Distributed under the Boost Software License, Version 1.0. 
-# (See accompanying file LICENSE_1_0.txt or copy at 
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
 import xml.sax.saxutils
@@ -26,7 +26,7 @@ import inspect
 
 
 class utils:
-    
+
     @staticmethod
     def log_level():
        frames = inspect.stack()
@@ -35,24 +35,24 @@ class utils:
            if i[0].f_locals.has_key( '__log__' ):
                level = level + i[0].f_locals[ '__log__' ]
        return level
-    
+
     @staticmethod
     def log( message ):
         sys.stderr.write( '# ' + '    ' * utils.log_level() +  message + '\n' )
         sys.stderr.flush()
-    
+
     @staticmethod
     def accept_args( args_spec, args, options, usage ):
-        
+
         defaults_num = len(options)
-        
+
         ( option_pairs, rest_args ) = getopt.getopt( args, '', args_spec )
         map( lambda x: options.__setitem__( x[0], x[1] ), option_pairs )
-    
+
         if ( options.has_key( '--help' ) or len( options.keys() ) == defaults_num ):
             usage()
             sys.exit( 1 )
-    
+
         if len( rest_args ) > 0 and rest_args[0][0] == '@':
             f = open( rest_args[0][1:], 'r' )
             config_lines  = f.read().splitlines()
@@ -65,7 +65,7 @@ class utils:
                     options[ '--%s' % m.group( 'name' ) ] = m.group( 'value' )
                 else:
                     raise 'Invalid format of config line "%s"' % l
-    
+
         return rest_args
 
 
@@ -75,7 +75,7 @@ def chr_or_question_mark( c ):
     else:
         return '?'
 
-char_translation_table = string.maketrans( 
+char_translation_table = string.maketrans(
       ''.join( map( chr, range(0, 256) ) )
     , ''.join( map( chr_or_question_mark, range(0, 256) ) )
     )
@@ -83,11 +83,11 @@ char_translation_table = string.maketrans(
 
 def process_xml_file( input_file, output_file ):
     utils.log( 'Processing test log "%s"' % input_file )
-    
+
     f = open( input_file, 'r' )
     xml = f.readlines()
     f.close()
-    
+
     for i in range( 0, len(xml)):
         xml[i] = string.translate( xml[i], char_translation_table )
 
@@ -144,7 +144,7 @@ class xmlrpcProxyTransport(xmlrpclib.Transport):
         connection.putrequest('POST','http://%s%s' % (self.realhost,handler))
     def send_host(self, connection, host):
         connection.putheader('Host',self.realhost)
-    
+
 
 def publish_test_logs(
     input_dirs,
@@ -157,7 +157,7 @@ def publish_test_logs(
     utils.log( 'Publishing test logs ...' )
     dart_rpc = None
     dart_dom = {}
-    
+
     def _publish_test_log_files_ ( unused, dir, names ):
         for file in names:
             if os.path.basename( file ) == 'test_log.xml':
@@ -219,7 +219,7 @@ def publish_test_logs(
                                 })
                             submission_dom.documentElement.appendChild(
                                 test_dom.documentElement.cloneNode(1) )
-    
+
     for input_dir in input_dirs:
         utils.log( 'Walking directory "%s" ...' % input_dir )
         os.path.walk( input_dir, _publish_test_log_files_, None )
@@ -234,24 +234,24 @@ def publish_test_logs(
             for dom in dart_dom.values():
                 #~ utils.log('Dart XML: %s' % dom.toxml('utf-8'))
                 dart_rpc.Submit.put(xmlrpclib.Binary(dom.toxml('utf-8')))
-        except Exception, e:
+        except Exception as e:
             utils.log('Dart server error: %s' % e)
 
 
 def upload_to_ftp( tag, results_file, ftp_proxy, debug_level, ftp_url ):
-    
+
     if not ftp_url:
         ftp_host = 'boost.cowic.de'
         ftp_url = ''.join(['ftp','://anonymous','@',ftp_host,'/boost/do-not-publish-this-url/results/'])
     utils.log( 'Uploading log archive "%s" to %s' % ( results_file, tag ) )
-    
+
     ftp_parts = urlparse.urlparse(ftp_url)
     ftp_netloc = re.split('[@]',ftp_parts[1])
     ftp_user = re.split('[:]',ftp_netloc[0])[0]
     ftp_password = re.split('[:]',ftp_netloc[0]+':anonymous')[1]
     ftp_site = re.split('[:]',ftp_netloc[1])[0]
     ftp_path = ftp_parts[2]
-    
+
     if not ftp_proxy:
         ftp = ftplib.FTP( ftp_site )
         ftp.set_debuglevel( debug_level )
@@ -285,7 +285,7 @@ def copy_comments( results_xml, comment_file ):
         try:
             results_xml.characters( f.read() )
         finally:
-            f.close()    
+            f.close()
     else:
         utils.log( 'Warning: comment file "%s" is not found.' % comment_file )
 
@@ -316,7 +316,7 @@ def copy_comments( results_xml, comment_file ):
     results_xml.characters( '</pre>' )
     results_xml.characters( '</dd>' )
     results_xml.characters( '</dl>\n' )
- 
+
     results_xml.endElement( 'comment' )
 
 
@@ -340,7 +340,7 @@ def compress_file( file_path, archive_path ):
             if os.path.exists( archive_path ):
                 os.unlink( archive_path )
                 utils.log( 'Removing stale "%s".' % archive_path )
-                
+
             zip_cmd.main( file_path, archive_path )
             utils.log( 'Done compressing "%s".' % archive_path )
 
@@ -355,7 +355,7 @@ def read_timestamp( file ):
     return time.gmtime( os.stat( file ).st_mtime )
 
 
-def collect_logs( 
+def collect_logs(
           results_dir
         , runner_id
         , tag
@@ -370,24 +370,24 @@ def collect_logs(
         , revision = ''
         , **unused
         ):
-    
+
     timestamp = time.strftime( '%Y-%m-%dT%H:%M:%SZ', read_timestamp( timestamp_file ) )
-    
+
     if dart_server:
         publish_test_logs( [ results_dir ],
             runner_id, tag, platform, comment_file, timestamp, user, source, run_type,
             dart_server = dart_server,
             http_proxy = http_proxy )
-    
+
     results_file = os.path.join( results_dir, '%s.xml' % runner_id )
     results_writer = open( results_file, 'w' )
     utils.log( 'Collecting test logs into "%s"...' % results_file )
-        
+
     results_xml = xml.sax.saxutils.XMLGenerator( results_writer )
     results_xml.startDocument()
-    results_xml.startElement( 
+    results_xml.startElement(
           'test-run'
-        , { 
+        , {
               'tag':        tag
             , 'platform':   platform
             , 'runner':     runner_id
@@ -397,7 +397,7 @@ def collect_logs(
             , 'revision':   revision
             }
         )
-    
+
     copy_comments( results_xml, comment_file )
     collect_test_logs( [ results_dir ], results_writer )
 
@@ -439,7 +439,7 @@ def upload_logs(
         upload_to_ftp( '%s/logs' % tag, logs_archive, ftp_proxy, debug_level, ftp_url )
 
 
-def collect_and_upload_logs( 
+def collect_and_upload_logs(
           results_dir
         , runner_id
         , tag
@@ -458,8 +458,8 @@ def collect_and_upload_logs(
         , ftp_url = None
         , **unused
         ):
-    
-    collect_logs( 
+
+    collect_logs(
           results_dir
         , runner_id
         , tag
@@ -473,7 +473,7 @@ def collect_and_upload_logs(
         , dart_server = dart_server
         , http_proxy = http_proxy
         )
-    
+
     upload_logs(
           results_dir
         , runner_id
@@ -489,7 +489,7 @@ def collect_and_upload_logs(
 
 
 def accept_args( args ):
-    args_spec = [ 
+    args_spec = [
           'locate-root='
         , 'runner='
         , 'tag='
@@ -508,7 +508,7 @@ def accept_args( args ):
         , 'revision='
         , 'ftp='
         ]
-    
+
     options = {
           '--tag'           : 'trunk'
         , '--platform'      : sys.platform
@@ -523,11 +523,11 @@ def accept_args( args ):
         , '--dart-server'   : 'beta.boost.org:8081'
         , '--revision'      : None
         , '--ftp'           : None
-        
+
         }
-    
+
     utils.accept_args( args_spec, args, options, usage )
-        
+
     return {
           'results_dir'     : options[ '--locate-root' ]
         , 'runner_id'       : options[ '--runner' ]
@@ -563,7 +563,7 @@ Commands:
 Options:
 \t--locate-root   directory to to scan for "test_log.xml" files
 \t--runner        runner ID (e.g. "Metacomm")
-\t--timestamp     path to a file which modification time will be used 
+\t--timestamp     path to a file which modification time will be used
 \t                as a timestamp of the run ("timestamp" by default)
 \t--comment       an HTML comment file to be inserted in the reports
 \t                ("comment.html" by default)
@@ -577,13 +577,13 @@ Options:
 \t--proxy         HTTP proxy server address and port (e.g.
 \t                'http://www.someproxy.com:3128', optional)
 \t--ftp-proxy     FTP proxy server (e.g. 'ftpproxy', optional)
-\t--debug-level   debugging level; controls the amount of debugging 
+\t--debug-level   debugging level; controls the amount of debugging
 \t                output printed; 0 by default (no debug output)
 \t--dart-server   The dart server to send results to.
 \t--ftp           The ftp URL to upload results to.
 ''' % '\n\t'.join( commands.keys() )
 )
-    
+
 def main():
     if len(sys.argv) > 1 and sys.argv[1] in commands:
         command = sys.argv[1]
@@ -591,7 +591,7 @@ def main():
     else:
         command = 'collect-and-upload'
         args = sys.argv[ 1: ]
-    
+
     commands[ command ]( **accept_args( args ) )
 
 

--- a/testing/src/collect_and_upload_logs.py
+++ b/testing/src/collect_and_upload_logs.py
@@ -41,7 +41,7 @@ class utils:
        frames = inspect.stack()
        level = 0
        for i in frames[ 3: ]:
-           if i[0].f_locals.has_key( '__log__' ):
+           if '__log__' in i[0].f_locals:
                level = level + i[0].f_locals[ '__log__' ]
        return level
 
@@ -58,7 +58,7 @@ class utils:
         ( option_pairs, rest_args ) = getopt.getopt( args, '', args_spec )
         map( lambda x: options.__setitem__( x[0], x[1] ), option_pairs )
 
-        if ( options.has_key( '--help' ) or len( options.keys() ) == defaults_num ):
+        if ( '--help' in options or len( options.keys() ) == defaults_num ):
             usage()
             sys.exit( 1 )
 
@@ -192,7 +192,7 @@ def publish_test_logs(
                         test['test-name'] = 'unknown'
                     if not test['toolset'] or test['toolset'] == '':
                         test['toolset'] = 'unknown'
-                    if not dart_dom.has_key(test['toolset']):
+                    if not test['toolset'] in dart_dom:
                         dart_dom[test['toolset']] = xml.dom.minidom.parseString(
 '''<?xml version="1.0" encoding="UTF-8"?>
 <DartSubmission version="2.0" createdby="collect_and_upload_logs.py">
@@ -556,7 +556,7 @@ def accept_args( args ):
         , 'ftp_proxy'       : options[ '--ftp-proxy' ]
         , 'http_proxy'      : options[ '--proxy' ]
         , 'debug_level'     : int(options[ '--debug-level' ])
-        , 'send_bjam_log'   : options.has_key( '--send-bjam-log' )
+        , 'send_bjam_log'   : '--send-bjam-log' in options
         , 'dart_server'     : options[ '--dart-server' ]
         , 'revision'        : options[ '--revision' ]
         , 'ftp'             : options[ '--ftp' ]

--- a/testing/src/collect_and_upload_logs.py
+++ b/testing/src/collect_and_upload_logs.py
@@ -555,8 +555,8 @@ commands = {
     }
 
 def usage():
-    print 'Usage: %s [command] [options]' % os.path.basename( sys.argv[0] )
-    print    '''
+    print('Usage: %s [command] [options]' % os.path.basename( sys.argv[0] ))
+    print(    '''
 Commands:
 \t%s
 
@@ -582,7 +582,7 @@ Options:
 \t--dart-server   The dart server to send results to.
 \t--ftp           The ftp URL to upload results to.
 ''' % '\n\t'.join( commands.keys() )
-
+)
     
 def main():
     if len(sys.argv) > 1 and sys.argv[1] in commands:

--- a/testing/src/collect_and_upload_logs.py
+++ b/testing/src/collect_and_upload_logs.py
@@ -84,7 +84,13 @@ def chr_or_question_mark( c ):
     else:
         return '?'
 
-char_translation_table = string.maketrans(
+
+if sys.version_info[0] == 3:
+    maketrans = str.maketrans
+else:
+    maketrans = string.maketrans
+
+char_translation_table = maketrans(
       ''.join( map( chr, range(0, 256) ) )
     , ''.join( map( chr_or_question_mark, range(0, 256) ) )
     )
@@ -98,7 +104,7 @@ def process_xml_file( input_file, output_file ):
     f.close()
 
     for i in range( 0, len(xml)):
-        xml[i] = string.translate( xml[i], char_translation_table )
+        xml[i] = xml[i].translate( char_translation_table )
 
     output_file.writelines( xml )
 

--- a/testing/src/process_jam_log.py
+++ b/testing/src/process_jam_log.py
@@ -64,19 +64,19 @@ class BJamLog2Results:
             'run-type' : run_type,
             'revision' : self.revision,
             } )
-        
+
         self.test = {}
         self.target_to_test = {}
         self.target = {}
         self.parent = {}
         self.log = {}
-        
+
         self.add_log()
         self.gen_output()
-        
+
         #~ print self.test
         #~ print self.target
-    
+
     def add_log(self):
         if self.input[0]:
             bjam_xml = self.input[0]
@@ -110,7 +110,7 @@ class BJamLog2Results:
                 if item:
                     test_run.appendChild(self.results.createTextNode("\n"))
                     test_run.appendChild(item)
-    
+
     def gen_output(self):
         if self.output:
             out = open(self.output,'w')
@@ -118,10 +118,10 @@ class BJamLog2Results:
             out = sys.stdout
         if out:
             self.results.writexml(out,encoding='utf-8')
-    
+
     def tostring(self):
         return self.results.toxml('utf-8')
-    
+
     def x_name_(self, *context, **kwargs):
         node = None
         names = [ ]
@@ -139,7 +139,7 @@ class BJamLog2Results:
                 if hasattr(self,name):
                     return (name,getattr(self,name))
         return None
-    
+
     def x(self, *context, **kwargs):
         node = None
         names = [ ]
@@ -159,13 +159,13 @@ class BJamLog2Results:
                 else:
                     assert False, 'Unknown node type %s'%(name)
         return None
-    
+
     #~ The timestamp goes to the corresponding attribute in the result.
     def x_build_timestamp( self, node ):
         test_run = self.results.documentElement
         test_run.setAttribute('timestamp',self.get_data(node).strip())
         return None
-    
+
     #~ Comment file becomes a comment node.
     def x_build_comment( self, node ):
         comment = None
@@ -177,7 +177,7 @@ class BJamLog2Results:
         if not comment:
             comment = ''
         return [self.new_text('comment',comment)]
-    
+
     #~ Tests are remembered for future reference.
     def x_build_test( self, node ):
         test_run = self.results.documentElement
@@ -195,7 +195,7 @@ class BJamLog2Results:
         self.target_to_test[self.test[test_name]['target']] = test_name
         #~ print "--- %s\n => %s" %(self.test[test_name]['target'],test_name)
         return None
-    
+
     #~ Process the target dependency DAG into an ancestry tree so we can look up
     #~ which top-level library and test targets specific build actions correspond to.
     def x_build_targets_target( self, node ):
@@ -219,7 +219,7 @@ class BJamLog2Results:
             #~ print "--- %s\n  ^ %s" %(jam_target,child_jam_target)
             dep_node = self.get_sibling(dep_node.nextSibling,tag='dependency')
         return None
-    
+
     #~ Given a build action log, process into the corresponding test log and
     #~ specific test log sub-part.
     def x_build_action( self, node ):
@@ -297,7 +297,7 @@ class BJamLog2Results:
                     result_node.appendChild(self.results.createTextNode("\n"))
                     result_node.appendChild(self.results.createTextNode(result_data))
         return None
-    
+
     #~ The command executed for the action. For run actions we omit the command
     #~ as it's just noise.
     def get_action_command( self, action_node, action_type ):
@@ -305,11 +305,11 @@ class BJamLog2Results:
             return self.get_child_data(action_node,tag='command')
         else:
             return ''
-    
+
     #~ The command output.
     def get_action_output( self, action_node, action_type ):
         return self.get_child_data(action_node,tag='output',default='')
-    
+
     #~ Some basic info about the action.
     def get_action_info( self, action_node, action_type ):
         info = ""
@@ -327,7 +327,7 @@ class BJamLog2Results:
                 info += "Define: %s\n" %(self.get_data(define,strip=True))
                 define = self.get_sibling(define.nextSibling,name='define')
         return info
-    
+
     #~ Find the test corresponding to an action. For testing targets these
     #~ are the ones pre-declared in the --dump-test option. For libraries
     #~ we create a dummy test as needed.
@@ -355,12 +355,12 @@ class BJamLog2Results:
             test = self.test[lib]
         else:
             target_name_ = self.target[target]['name']
-            if self.target_to_test.has_key(target_name_):
+            if target_name_ in self.target_to_test:
                 test = self.test[self.target_to_test[target_name_]]
             else:
                 test = None
         return (base,test)
-    
+
     #~ Find, or create, the test-log node to add results to.
     def get_log( self, node, test ):
         target_directory = os.path.dirname(self.get_child_data(
@@ -381,7 +381,7 @@ class BJamLog2Results:
                 target_directory=target_directory,
                 show_run_output=show_run_output)
         return self.log[target_directory]
-    
+
     #~ The precise toolset from the build properties.
     def get_toolset( self, node ):
         toolset = self.get_child_data(self.get_child(node,tag='properties'),
@@ -389,9 +389,9 @@ class BJamLog2Results:
         toolset_version = self.get_child_data(self.get_child(node,tag='properties'),
             name='toolset-%s:version'%toolset,strip=True)
         return '%s-%s' %(toolset,toolset_version)
-    
+
     #~ XML utilities...
-    
+
     def get_sibling( self, sibling, tag = None, id = None, name = None, type = None ):
         n = sibling
         while n:
@@ -413,10 +413,10 @@ class BJamLog2Results:
                 return n
             n = n.nextSibling
         return None
-    
+
     def get_child( self, root, tag = None, id = None, name = None, type = None ):
         return self.get_sibling(root.firstChild,tag=tag,id=id,name=name,type=type)
-    
+
     def get_data( self, node, strip = False, default = None ):
         data = None
         if node:
@@ -439,10 +439,10 @@ class BJamLog2Results:
             if strip:
                 data = data.strip()
         return data
-    
+
     def get_child_data( self, root, tag = None, id = None, name = None, strip = False, default = None ):
         return self.get_data(self.get_child(root,tag=tag,id=id,name=name),strip=strip,default=default)
-    
+
     def new_node( self, tag, *child, **kwargs ):
         result = self.results.createElement(tag)
         for k in kwargs.keys():
@@ -457,7 +457,7 @@ class BJamLog2Results:
             if c:
                 result.appendChild(c)
         return result
-    
+
     def new_text( self, tag, data, **kwargs ):
         result = self.new_node(tag,**kwargs)
         data = data.strip()

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -47,7 +47,7 @@ git_branch = {
     }
 
 class utils:
-    
+
     @staticmethod
     def system( commands ):
         if sys.platform == 'win32':
@@ -59,20 +59,20 @@ class utils:
         else:
             rc = os.system( '&&'.join( commands ) )
             return rc
-    
-        
+
+
     @staticmethod
     def checked_system( commands, valid_return_codes = [ 0 ] ):
-        rc = utils.system( commands ) 
+        rc = utils.system( commands )
         if rc not in [ 0 ] + valid_return_codes:
             raise Exception( 'Command sequence "%s" failed with return code %d' % ( commands, rc ) )
         return rc
-    
+
     @staticmethod
     def makedirs( path ):
         if not os.path.exists( path ):
             os.makedirs( path )
-    
+
     @staticmethod
     def log_level():
        frames = inspect.stack()
@@ -81,7 +81,7 @@ class utils:
            if i[0].f_locals.has_key( '__log__' ):
                level = level + i[0].f_locals[ '__log__' ]
        return level
-    
+
     @staticmethod
     def log( message ):
         sys.stderr.write( '# ' + '    ' * utils.log_level() +  message + '\n' )
@@ -209,7 +209,7 @@ class runner:
 
         #~ Initialize option dependent values.
         self.regression_root = root
-        
+
         #~ Boost paths.
         self.boost_root = os.path.join( self.regression_root, 'boost_root' )
         self.regression_results = os.path.join( self.regression_root, 'results' )
@@ -217,16 +217,16 @@ class runner:
             self.regression_log = os.path.join( self.regression_results, 'bjam.log' )
         else:
             self.regression_log = os.path.join( self.regression_results, 'bjam.xml' )
-        
+
         #~ Boost Build paths.
         self.tools_bb_root = os.path.join( self.regression_root,'boost_bb' )
         self.tools_bb_root = os.path.join( self.tools_bb_root, 'src')
         self.tools_bjam_root = os.path.join( self.regression_root,'boost_bb', 'src', 'engine' )
-        
+
         #~ Regression tools paths.
         self.tools_regression_root = os.path.join( self.regression_root,'boost_regression' )
         self.xsl_reports_dir = os.path.join( self.tools_regression_root, 'xsl_reports' )
-        
+
         self.timestamp_path = os.path.join( self.regression_root, 'timestamp' )
         if sys.platform == 'win32':
             self.patch_boost = 'patch_boost.bat'
@@ -444,7 +444,7 @@ class runner:
 
         source = 'tarball'
         revision = self.git_revision(self.boost_root)
-        
+
         # Generate expanded comment file that has extra status
         # information. In particular the revisions of all the git
         # repos in the test tree.
@@ -611,8 +611,8 @@ class runner:
 
         import re
         re_keyword_value = re.compile( r'^\$\w+:\s+(.*)\s+\$$' )
-        print '\n\tRevision: %s' % re_keyword_value.match( revision ).group( 1 )
-        print '\tLast modified on: %s\n' % re_keyword_value.match( modified ).group( 1 )
+        print('\n\tRevision: %s' % re_keyword_value.match( revision ).group( 1 ))
+        print('\tLast modified on: %s\n' % re_keyword_value.match( modified ).group( 1 ))
 
     #~ Utilities...
 
@@ -879,7 +879,7 @@ class runner:
             return git_branch[self.tag]
         else:
             return self.tag
-    
+
     def git_revision(self, root):
         result = ''
         if self.use_git:
@@ -1007,5 +1007,3 @@ class runner:
                 glob.glob( os.path.join( self.regression_root, 'boost[-_]*' ) )
                 if os.path.isdir( x )
             ]
-
-

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -637,11 +637,12 @@ class runner:
     def rmtree(self,path):
         if os.path.exists( path ):
             import shutil
-            from builtins import str
+            if sys.version_info[0] == 3:
+                unicode = str
             #~ shutil.rmtree( unicode( path ) )
             if sys.platform == 'win32':
                 os.system( 'del /f /s /q "%s" >nul 2>&1' % path )
-                shutil.rmtree( str( path ) )
+                shutil.rmtree( unicode( path ) )
             else:
                 os.system( 'rm -f -r "%s"' % path )
 

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -669,15 +669,15 @@ class runner:
 
     def http_get( self, source_url, destination_file ):
         try:
-            from urllib.request import urlopen
+            from urllib.request import urlopen, Request
         except ImportError:
-            from urllib import urlopen
+            from urllib2 import urlopen, Request
 
-        proxies = None
+        req = Request(source_url)
         if hasattr(self,'proxy') and self.proxy is not None:
-            proxies = { 'https' : self.proxy }
+            req.set_proxy('https', self.proxy)
 
-        src = urlopen( source_url, proxies = proxies )
+        src = urlopen( req )
 
         f = open( destination_file, 'wb' )
         while True:

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -90,12 +90,12 @@ class utils:
 class runner:
 
     def __init__(self,root):
-        commands = map(
+        commands = list(map(
             lambda m: m[8:].replace('_','-'),
             filter(
                 lambda m: m.startswith('command_'),
                 runner.__dict__.keys())
-            )
+            ))
         commands.sort()
         commands = "commands: %s" % ', '.join(commands)
 

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -710,7 +710,7 @@ class runner:
         else:
             raise 'Could not find "%s" source directory "%s"' % ( tool[ 'name' ], tool[ 'source_dir' ] )
 
-        if not tool.has_key( 'build_path' ):
+        if not 'build_path' in tool:
             tool[ 'build_path' ] = self.tool_path( tool )
 
         if not os.path.exists( tool[ 'build_path' ] ):
@@ -725,7 +725,7 @@ class runner:
         if os.path.exists( name_or_spec[ 'path' ] ):
             return name_or_spec[ 'path' ]
 
-        if name_or_spec.has_key( 'build_path' ):
+        if 'build_path' in name_or_spec:
             return name_or_spec[ 'build_path' ]
 
         build_dir = name_or_spec[ 'build_dir' ]
@@ -875,7 +875,7 @@ class runner:
         self.git_checkout(git_info['boost'], self.git_branch(), clean)
 
     def git_branch(self):
-        if git_branch.has_key(self.tag):
+        if self.tag in git_branch:
             return git_branch[self.tag]
         else:
             return self.tag

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -668,13 +668,16 @@ class runner:
                 time.sleep( sleep_secs )
 
     def http_get( self, source_url, destination_file ):
-        import urllib
+        try:
+            from urllib.request import urlopen
+        except ImportError:
+            from urllib import urlopen
 
         proxies = None
         if hasattr(self,'proxy') and self.proxy is not None:
             proxies = { 'https' : self.proxy }
 
-        src = urllib.urlopen( source_url, proxies = proxies )
+        src = urlopen( source_url, proxies = proxies )
 
         f = open( destination_file, 'wb' )
         while True:

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -77,7 +77,7 @@ class utils:
        frames = inspect.stack()
        level = 0
        for i in frames[ 3: ]:
-           if i[0].f_locals.has_key( '__log__' ):
+           if '__log__' in i[0].f_locals:
                level = level + i[0].f_locals[ '__log__' ]
        return level
 
@@ -752,7 +752,7 @@ class runner:
         else:
             cmd = './build.sh %s' % self.bjam_toolset
         env_setup_key = 'BJAM_ENVIRONMENT_SETUP'
-        if os.environ.has_key( env_setup_key ):
+        if env_setup_key in os.environ:
             return '%s & %s' % ( os.environ[env_setup_key], cmd )
         return cmd
 

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -660,7 +660,7 @@ class runner:
         for attempts in range( max_attempts, -1, -1 ):
             try:
                 return f()
-            except Exception, msg:
+            except Exception as msg:
                 self.log( '%s failed with message "%s"' % ( f.__name__, msg ) )
                 if attempts == 0:
                     self.log( 'Giving up.' )
@@ -805,7 +805,7 @@ class runner:
             z.write( file_path, os.path.basename( file_path ) )
             z.close()
             utils.log( 'Done writing "%s".'% archive_path )
-        except Exception, msg:
+        except Exception as msg:
             utils.log( 'Warning: Compressing falied (%s)' % msg )
             utils.log( '         Trying to compress using a platform-specific tool...' )
             try:

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -637,10 +637,11 @@ class runner:
     def rmtree(self,path):
         if os.path.exists( path ):
             import shutil
+            from builtins import str
             #~ shutil.rmtree( unicode( path ) )
             if sys.platform == 'win32':
                 os.system( 'del /f /s /q "%s" >nul 2>&1' % path )
-                shutil.rmtree( unicode( path ) )
+                shutil.rmtree( str( path ) )
             else:
                 os.system( 'rm -f -r "%s"' % path )
 

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -13,7 +13,6 @@ import optparse
 import os
 import os.path
 import platform
-import string
 import sys
 import time
 
@@ -52,7 +51,7 @@ class utils:
     def system( commands ):
         if sys.platform == 'win32':
             f = open( 'tmp.cmd', 'w' )
-            f.write( string.join( commands, '\n' ) )
+            f.write( "".join( commands, '\n' ) )
             f.close()
             rc = os.system( 'tmp.cmd' )
             return rc
@@ -547,10 +546,9 @@ class runner:
 
     def command_regression(self):
         import socket
-        import string
         try:
             mail_subject = 'Boost regression for %s on %s' % ( self.tag,
-                string.split(socket.gethostname(), '.')[0] )
+                socket.gethostname().split('.')[0] )
             start_time = time.localtime()
             if self.mail:
                 self.log( 'Sending start notification to "%s"' % self.mail )
@@ -696,7 +694,7 @@ class runner:
 
         if toolset is None:
             if self.toolsets is not None:
-                toolset = string.split( self.toolsets, ',' )[0]
+                toolset = self.toolsets.split(',' )[0]
             else:
                 toolset = tool[ 'default_toolset' ]
                 self.log( 'Warning: No bootstrap toolset for "%s" was specified.' % tool[ 'name' ] )
@@ -719,6 +717,12 @@ class runner:
         self.log( '%s succesfully built in "%s" location' % ( tool[ 'name' ], tool[ 'build_path' ] ) )
 
     def tool_path( self, name_or_spec ):
+        # Python 2 and 3 compatible
+        try:
+            basestring
+        except NameError:
+            basestring = str
+
         if isinstance( name_or_spec, basestring ):
             return os.path.join( self.regression_root, name_or_spec )
 
@@ -785,7 +789,7 @@ class runner:
             password = None
         else:
             server_name = self.smtp_login.split( '@' )[-1]
-            ( user_name, password ) = string.split( self.smtp_login.split( '@' )[0], ':' )
+            ( user_name, password ) = self.smtp_login.split( '@' )[0].split(':')
 
         log( '    Sending mail through "%s"...' % server_name )
         smtp_server = smtplib.SMTP( server_name )

--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -51,7 +51,7 @@ class utils:
     def system( commands ):
         if sys.platform == 'win32':
             f = open( 'tmp.cmd', 'w' )
-            f.write( "".join( commands, '\n' ) )
+            f.write( "\n".join( commands ) )
             f.close()
             rc = os.system( 'tmp.cmd' )
             return rc

--- a/testing/src/run.py
+++ b/testing/src/run.py
@@ -11,9 +11,9 @@ import os.path
 import shutil
 import sys
 try:
-    from urllib.request import FancyURLOpener
+    from urllib.request import FancyURLopener
 except ImportError:
-    from urllib import FancyURLOpener
+    from urllib import FancyURLopener
 
 #~ Using --skip-script-download is useful to avoid repeated downloading of
 #~ the regression scripts when doing the regression commands individually.

--- a/testing/src/run.py
+++ b/testing/src/run.py
@@ -10,7 +10,10 @@ import os
 import os.path
 import shutil
 import sys
-import urllib
+try:
+    from urllib.request import FancyURLOpener
+except ImportError:
+    from urllib import FancyURLOpener
 
 #~ Using --skip-script-download is useful to avoid repeated downloading of
 #~ the regression scripts when doing the regression commands individually.
@@ -29,7 +32,7 @@ if use_local:
     root = os.path.abspath(os.path.realpath(os.path.curdir))
 else:
     root = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-print '# Running regressions in %s...' % root
+print('# Running regressions in %s...' % root)
 
 script_sources = [ 'collect_and_upload_logs.py', 'process_jam_log.py', 'regression.py' ]
 script_local = root
@@ -42,25 +45,25 @@ script_dir = os.path.join(root,'boost_regression_src')
 if not no_update:
     #~ Bootstrap.
     #~ * Clear out any old versions of the scripts
-    print '# Creating regression scripts at %s...' % script_dir
+    print('# Creating regression scripts at %s...' % script_dir)
     if os.path.exists(script_dir):
         shutil.rmtree(script_dir)
     os.mkdir(script_dir)
     #~ * Get new scripts, either from local working copy, or from remote
     if use_local and os.path.exists(script_local):
-        print '# Copying regression scripts from %s...' % script_local
+        print('# Copying regression scripts from %s...' % script_local)
         for src in script_sources:
             shutil.copyfile( os.path.join(script_local,src), os.path.join(script_dir,src) )
     else:
-        print '# Downloading regression scripts from %s...' % script_remote
+        print('# Downloading regression scripts from %s...' % script_remote)
         proxy = None
         for a in sys.argv[1:]:
             if a.startswith('--proxy='):
                 proxy = {'https' : a.split('=')[1] }
-                print '--- %s' %(proxy['https'])
+                print('--- %s' %(proxy['https']))
                 break
         for src in script_sources:
-            urllib.FancyURLopener(proxy).retrieve(
+            FancyURLopener(proxy).retrieve(
                 '%s/%s' % (script_remote,src), os.path.join(script_dir,src) )
 
 #~ * Make the scripts available to Python


### PR DESCRIPTION
I've made the changes to follow the program through in both version of python. This Fixes #43. 

Please don't merge yet, there are two known defects.

Different results
-------------------

The windows version shows slightly different results on windows. Looking at the [develop results](https://www.boost.org/development/tests/develop/developer/summary.html) the `teeks99-test-py23-p2-w` and `teeks99-test-py23-p3-w` they are the same except for the `build`results which are missing for the python 3 version. 

Different output
--------------------

On linux (running python 3.5), I get an exception running through the log for regex. Running with Python 3 the file `results/boost/bin.v2/libs/regex/example/icu_example.test/gcc-8~c++2a/debug/threading-multi/visibility-hidden/test_log.xml` contains:

```
<test-log library="regex" revision="38afec" test-name="icu_example" test-type="run" test-program="libs/regex/example/snippets/icu_example.cpp" target-directory="boost/bin.v2/libs/regex/example/icu_example.test/gcc-8~c++2a/debug/threading-multi/visibility-hidden" toolset="gcc-8~c++2a" show-run-output="false">
<compile result="succeed" timestamp="2018-10-27 08:59:04 UTC">
"g++-8"   -fvisibility-inlines-hidden -std=c++2a -fPIC -m64 -pthread -O0 -fno-inline -Wall -pedantic -g -fvisibility=hidden -Wextra -DBOOST_ALL_NO_LIB=1 -DBOOST_HAS_ICU=1 -DBOOST_REGEX_DYN_LINK=1 -DU_USING_ICU_NAMESPACE=0  -I".." -c -o "/var/boost/run/results/boost/bin.v2/libs/regex/example/icu_example.test/gcc-8~c++2a/debug/threading-multi/visibility-hidden/snippets/icu_example.o" "../libs/regex/example/snippets/icu_example.cpp"

</compile>
<link result="succeed" timestamp="2018-10-27 08:59:04 UTC">
"g++-8"  -Wl,-rpath -Wl,"/var/boost/run/results/boost/bin.v2/libs/regex/build/gcc-8~c++2a/debug/threading-multi/visibility-hidden" -Wl,-rpath-link -Wl,"/var/boost/run/results/boost/bin.v2/libs/regex/build/gcc-8~c++2a/debug/threading-multi/visibility-hidden" -o "/var/boost/run/results/boost/bin.v2/libs/regex/example/icu_example.test/gcc-8~c++2a/debug/threading-multi/visibility-hidden/icu_example" -Wl,--start-group "/var/boost/run/results/boost/bin.v2/libs/regex/example/icu_example.test/gcc-8~c++2a/debug/threading-multi/visibility-hidden/snippets/icu_example.o" "/var/boost/run/results/boost/bin.v2/libs/regex/build/gcc-8~c++2a/debug/threading-multi/visibility-hidden/libboost_regex.so.1.69.0"  -Wl,-Bstatic  -Wl,-Bdynamic -lrt -licudata -licui18n -licuuc -Wl,--end-group -fPIC -m64 -pthread -g -fvisibility=hidden -fvisibility-inlines-hidden 

</link>
<run result="succeed" timestamp="2018-10-27 08:59:04 UTC">
$100.23
£198.12
$
£

EXIT STATUS: 0
</run>
</test-log>
```

whereas the python 2 version contains:

```
<test-log library="regex" revision="38afec" test-name="icu_example" test-type="run" test-program="libs/regex/example/snippets/icu_example.cpp" target-directory="boost/bin.v2/libs/regex/example/icu_example.test/gcc-8~c++2a/debug/threading-multi/visibility-hidden" toolset="gcc-8~c++2a" show-run-output="false">
<compile result="succeed" timestamp="2018-10-27 09:03:39 UTC">
"g++-8"   -fvisibility-inlines-hidden -std=c++2a -fPIC -m64 -pthread -O0 -fno-inline -Wall -pedantic -g -fvisibility=hidden -Wextra -DBOOST_ALL_NO_LIB=1 -DBOOST_HAS_ICU=1 -DBOOST_REGEX_DYN_LINK=1 -DU_USING_ICU_NAMESPACE=0  -I".." -c -o "/var/boost/run/results/boost/bin.v2/libs/regex/example/icu_example.test/gcc-8~c++2a/debug/threading-multi/visibility-hidden/snippets/icu_example.o" "../libs/regex/example/snippets/icu_example.cpp"

</compile>
<link result="succeed" timestamp="2018-10-27 09:03:39 UTC">
"g++-8"  -Wl,-rpath -Wl,"/var/boost/run/results/boost/bin.v2/libs/regex/build/gcc-8~c++2a/debug/threading-multi/visibility-hidden" -Wl,-rpath-link -Wl,"/var/boost/run/results/boost/bin.v2/libs/regex/build/gcc-8~c++2a/debug/threading-multi/visibility-hidden" -o "/var/boost/run/results/boost/bin.v2/libs/regex/example/icu_example.test/gcc-8~c++2a/debug/threading-multi/visibility-hidden/icu_example" -Wl,--start-group "/var/boost/run/results/boost/bin.v2/libs/regex/example/icu_example.test/gcc-8~c++2a/debug/threading-multi/visibility-hidden/snippets/icu_example.o" "/var/boost/run/results/boost/bin.v2/libs/regex/build/gcc-8~c++2a/debug/threading-multi/visibility-hidden/libboost_regex.so.1.69.0"  -Wl,-Bstatic  -Wl,-Bdynamic -lrt -licudata -licui18n -licuuc -Wl,--end-group -fPIC -m64 -pthread -g -fvisibility=hidden -fvisibility-inlines-hidden 

</link>
<run result="succeed" timestamp="2018-10-27 09:03:39 UTC">
$100.23
<C2><A3>198.12
$
<C2><A3>

EXIT STATUS: 0
</run>
</test-log>
```

The difference on the `£198.12` vs. `<C2><A3>198.12` causes a `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1803: ordinal not in range(128)`. Any ideas what could be causing the differences in the xml files? Something about the environment that runs the tests?

