### PR TITLE
Fixed incorrect iterator advancing

### DIFF
--- a/common/src/process_jam_log.cpp
+++ b/common/src/process_jam_log.cpp
@@ -641,7 +641,7 @@ int process_jam_log( const std::vector<std::string> & args )
 
   std::vector<std::string>::const_iterator args_i = args.begin();
   std::vector<std::string>::const_iterator args_e = args.end();
-  for(++args_i; args_i != args_e; ++args_i)
+  for(; args_i != args_e; ++args_i)
   {
     if ( *args_i == "--echo" )
     {


### PR DESCRIPTION
`args` always doesn't contain program name, so it shouldn't advance the iterator at first.

Callers are always skipping its name.
https://github.com/boostorg/regression/blob/4d4c503253f5254f08f2912bc14fabeae2bcce33/testing/src/process_jam_log.cpp#L21-L26
https://github.com/boostorg/regression/blob/4d4c503253f5254f08f2912bc14fabeae2bcce33/library_status/src/library_status.cpp#L925-L933