### PR TITLE
New version of b2 stops using the bjam.exe name

### DIFF
--- a/testing/src/regression.py
+++ b/testing/src/regression.py
@@ -230,7 +230,7 @@ class runner:
         self.timestamp_path = os.path.join( self.regression_root, 'timestamp' )
         if sys.platform == 'win32':
             self.patch_boost = 'patch_boost.bat'
-            self.bjam = { 'name' : 'bjam.exe' }
+            self.bjam = { 'name' : 'b2.exe' }
             self.process_jam_log = { 'name' : 'process_jam_log.exe' }
         elif sys.platform == 'cygwin':
             self.patch_boost = 'patch_boost'


### PR DESCRIPTION
Regression tests are broken for windows on develop. I think this will fix it.