### PR TITLE
Upload reports to original.boost.org

### DIFF
--- a/ci_build_results_all.sh
+++ b/ci_build_results_all.sh
@@ -228,8 +228,8 @@ upload_results()
 
     # Upload to wowbagger
     rsync -vuz "--rsh=ssh -o StrictHostKeyChecking=no -l grafik" --stats \
-      ${1}${upload_ext} grafik@www.boost.org:/${upload_dir}/incoming/ || true
-    ssh grafik@www.boost.org \
+      ${1}${upload_ext} grafik@original.boost.org:/${upload_dir}/incoming/ || true
+    ssh grafik@original.boost.org \
       mv ${upload_dir}/incoming/${1}${upload_ext} ${upload_dir}/live/${1}.zip || true
 
     # Upload to regression.boost.io


### PR DESCRIPTION
Caution: this first requires adding an SSH key in https://app.circleci.com/pipelines/github/boostorg/regression . Project Settings ->  Additional SSH Keys -> Add SSH Key -> Hostname, Private Key . 

Hostname: original.boost.org
Private Key: get from grafikrobot

More details:

After switching the DNS boost.org to the new website, the reports will fail to upload to the original website unless these changes are made.  

There is no requirement to wait for DNS.  original.boost.org is pointing to wowbagger currently.  
